### PR TITLE
cmake: Remove installation of include/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,4 +19,3 @@ endif()
 
 install(TARGETS libnecrolog)
 install(DIRECTORY libnecrolog TYPE INCLUDE FILES_MATCHING PATTERN "*.h")
-install(DIRECTORY include/ TYPE INCLUDE)


### PR DESCRIPTION
These aren't needed - the headers in the libnecrolog directory are
sufficient.